### PR TITLE
Upgrade to .NET 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOTNET_VERSION: '8'
+  DOTNET_VERSION: '9'
 
 jobs:
   build:
@@ -77,6 +77,11 @@ jobs:
       attestations: write
       id-token: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ﻿#==== BASE
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 WORKDIR /app
 
 # Creates a non-root user with an explicit UID and adds permission to access the /app folder
@@ -10,7 +10,7 @@ EXPOSE 8080
 EXPOSE 8081
 
 #==== BUILD
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Kasta.Web/Kasta.Web.csproj", "Kasta.Web/"]

--- a/Kasta.Data/Kasta.Data.csproj
+++ b/Kasta.Data/Kasta.Data.csproj
@@ -8,13 +8,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GeoTimeZone" Version="5.3.0" />
+    <PackageReference Include="GeoTimeZone" Version="6.0.0" />
     <PackageReference Include="MaxMind.GeoIP2" Version="5.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="9.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.1" />
     <PackageReference Include="NLog" Version="5.3.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Kasta.Data/Kasta.Data.csproj
+++ b/Kasta.Data/Kasta.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Kasta.Data</RootNamespace>

--- a/Kasta.Shared/Kasta.Shared.csproj
+++ b/Kasta.Shared/Kasta.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Kasta.Shared</RootNamespace>

--- a/Kasta.Web/Kasta.Web.csproj
+++ b/Kasta.Web/Kasta.Web.csproj
@@ -15,28 +15,32 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="8.3.0" />
-        <PackageReference Include="AWSSDK.S3" Version="3.7.407.1" />
+        <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="9.0.0" />
+        <PackageReference Include="AWSSDK.S3" Version="3.7.413.1" />
         <PackageReference Include="EasyCaching.InMemory" Version="1.9.2" />
         <PackageReference Include="EasyCaching.Redis" Version="1.9.2" />
         <PackageReference Include="EasyCaching.Serialization.MessagePack" Version="1.9.2" />
-        <PackageReference Include="EFCoreSecondLevelCacheInterceptor" Version="4.9.0" />
-        <PackageReference Include="Magick.NET-Q16-HDRI-AnyCPU" Version="14.2.0" />
-        <PackageReference Include="Markdig" Version="0.38.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.11" />
-        <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.10" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10" />
+        <PackageReference Include="EFCoreSecondLevelCacheInterceptor" Version="5.0.0" />
+        <PackageReference Include="EFCoreSecondLevelCacheInterceptor.EasyCaching.Core" Version="5.0.0" />
+        <PackageReference Include="Magick.NET-Q16-HDRI-AnyCPU" Version="14.4.0" />
+        <PackageReference Include="Markdig" Version="0.40.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.1">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
         <PackageReference Include="MimeTypes" Version="2.5.2" />
         <PackageReference Include="NLog" Version="5.3.4" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
         <PackageReference Include="NLog.Web.AspNetCore" Version="5.3.15" />
-        <PackageReference Include="Sentry.AspNetCore" Version="5.0.0" />
-        <PackageReference Include="Sentry.NLog" Version="5.0.0" />
-        <PackageReference Include="Vivet.AspNetCore.RequestTimeZone" Version="8.1.1" />
+        <PackageReference Include="Sentry.AspNetCore" Version="5.0.1" />
+        <PackageReference Include="Sentry.NLog" Version="5.0.1" />
+        <PackageReference Include="Vivet.AspNetCore.RequestTimeZone" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Kasta.Web/Kasta.Web.csproj
+++ b/Kasta.Web/Kasta.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>aspnet-Kasta-be2e7886-b576-461b-9096-e78871b03d07</UserSecretsId>


### PR DESCRIPTION
This pull requests upgrades Kasta to use .NET 9.

Updated the following dependencies
- AspNet.Security.OAuth.GitHub 9.0.0
- AWSSDK.S3 3.7.413.1
- EFCoreSecondLevelCacheInterceptor 5.0.0
  - Added dependency `EFCoreSecondLevelCacheInterceptor.EasyCaching.Core` 5.0.0
- Magick.NET-Q16-HDRI-AnyCPU 14.4.0
- Markdig 0.40.0
- GeoTimeZone 6.0.0
- Microsoft.AspNetCore.Authentication.JwtBearer 9.0.1
- Microsoft.AspNetCore.Authentication.OpenIdConnect 9.0.1
- Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore 9.0.1
- Microsoft.AspNetCore.DataProtection.EntityFrameworkCore 9.0.1
- Microsoft.AspNetCore.Identity.EntityFrameworkCore 9.0.1
- Microsoft.AspNetCore.Identity.UI 9.0.1
- Microsoft.EntityFrameworkCore.Tools 9.0.1
- Npgsql.EntityFrameworkCore.PostgreSQL 9.0.3
- Sentry.AspNetCore 5.0.1
- Sentry.NLog 5.0.1
- Vivet.AspNetCore.RequestTimeZone 9.0.0