### PR TITLE
Show NuGet Packages in Licenses page

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,11 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
       
+      - name: Get Licenses
+        run: |
+          dotnet tool install --global nuget-license
+          dotnet tool run nuget-license -i Kasta.Web/Kasta.Web.csproj -o Json -fo Kasta.Web/app-licenses.json
+
       - name: Build ${{ matrix.runtime }}
         run: dotnet publish Kasta.Web --configuration Release -p:PublishSingleFile=true -p:ReadyToRun=true -p:IncludeNativeLibrariesForSelfExtract=true -p:CopyOutputSymbolsToPublishDirectory=false --self-contained --runtime ${{ matrix.runtime }} --output dist
       

--- a/.gitignore
+++ b/.gitignore
@@ -416,3 +416,6 @@ dist
 docker-compose.yml
 docker-compose*.yml
 !docker-compose.example.yml
+
+# App Licenses
+Kasta.Web/app-licenses.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,15 @@ COPY ["Kasta.Web/Kasta.Web.csproj", "Kasta.Web/"]
 RUN dotnet restore "Kasta.Web/Kasta.Web.csproj"
 COPY . .
 WORKDIR "/src/Kasta.Web"
+RUN dotnet tool install --global nuget-license
+RUN nuget-license -i Kasta.Web.csproj -o Json -fo app-licenses.json
 RUN dotnet build "Kasta.Web.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 #==== PUBLISH
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
+RUN dotnet tool install --global nuget-license
+RUN nuget-license -i Kasta.Web.csproj -o Json -fo app-licenses.json
 RUN dotnet publish "Kasta.Web.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 #==== FINAL

--- a/Kasta.Web/Controllers/HomeController.cs
+++ b/Kasta.Web/Controllers/HomeController.cs
@@ -335,7 +335,13 @@ public class HomeController : Controller
         var vm = new LicensesViewModel
         {
             Licenses = data,
-            OtherLibraries = LicenseHelper.GetOtherLibraries()
+            OtherLibraries = [],
+#if RELEASE
+            HasPackageLicenses = true
+#else
+            HasPackageLicenses = false
+#endif
+
         };
         return View("Licenses", vm);
     }

--- a/Kasta.Web/Kasta.Web.csproj
+++ b/Kasta.Web/Kasta.Web.csproj
@@ -22,11 +22,15 @@
         <PackageReference Include="EasyCaching.Serialization.MessagePack" Version="1.9.2" />
         <PackageReference Include="EFCoreSecondLevelCacheInterceptor" Version="5.3.1" />
         <PackageReference Include="EFCoreSecondLevelCacheInterceptor.EasyCaching.Core" Version="5.3.1" />
-        <PackageReference Include="Magick.NET-Q16-HDRI-AnyCPU" Version="14.8.1" />
+		<PackageReference Include="GeoTimeZone" Version="6.0.0" />
+		<PackageReference Include="Magick.NET-Q16-HDRI-AnyCPU" Version="14.8.1" />
+		<PackageReference Include="MaxMind.GeoIP2" Version="5.3.0" />
         <PackageReference Include="Markdig" Version="0.41.3" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.8" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="9.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.8" />
+		<PackageReference Include="Microsoft.AspNetCore.HttpOverrides" Version="2.3.5" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.8" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8">

--- a/Kasta.Web/Kasta.Web.csproj
+++ b/Kasta.Web/Kasta.Web.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -47,6 +47,11 @@
         <PackageReference Include="Vivet.AspNetCore.RequestTimeZone" Version="9.0.0" />
     </ItemGroup>
 
+	<ItemGroup Condition="'$(Configuration)' == 'Release'">
+		<Content Remove="app-licenses.json" />
+		<EmbeddedResource Include="app-licenses.json" />
+	</ItemGroup>
+	
     <ItemGroup>
       <Content Include="..\.dockerignore">
         <Link>.dockerignore</Link>

--- a/Kasta.Web/Models/LicensesViewModel.cs
+++ b/Kasta.Web/Models/LicensesViewModel.cs
@@ -4,6 +4,7 @@ namespace Kasta.Web.Models;
 
 public class LicensesViewModel
 {
+    public bool HasPackageLicenses { get; init; }
     public required IReadOnlyList<LicenseItem> Licenses { get; init; }
     public required IReadOnlyList<OtherLibraryInfo> OtherLibraries { get; init; }
 }

--- a/Kasta.Web/Views/Home/Licenses.cshtml
+++ b/Kasta.Web/Views/Home/Licenses.cshtml
@@ -11,6 +11,14 @@
 
 <h3>Software Licenses</h3>
 
+@if (!Model.HasPackageLicenses)
+{
+    <div class="alert alert-warning" role="alert">
+        Kasta was not compiled with the <code>Release</code> configuration, so the NuGet package licenses weren't included.<br/>
+        Because of this, the reported library versions may be incorrect, and might not reflect what package version is actually being used.
+    </div>
+}
+
 <div class="row d-flex flex-row">
     @foreach (var item in Model.Licenses.OrderBy(e => e.Info.Name))
     {


### PR DESCRIPTION
This PR adds support to see the actual version reported by NuGet packages, and the actual version of the NuGet package instead of the Assembly Version.

This is what the new page looks like:

<img width="1280" height="764" alt="firefox_dwauX5XCZy-1" src="https://github.com/user-attachments/assets/141a4f1f-0b48-4f73-b2a0-f24657ee2bd2" />

And this is what the current deployed version looks like:

<img width="1280" height="764" alt="firefox_VdW5gykYEF" src="https://github.com/user-attachments/assets/f097de9f-e23e-4002-b173-a5cf25864fb8" />
